### PR TITLE
remote_list: fetch it using HTTP/1.1

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,10 @@ pub fn request<U: IntoUrl>(u: U) -> Result<String> {
             return Err(ErrorKind::NoHost.into());
         }
     };
-    let data = format!("GET {} HTTP/1.0\r\nHost: {}\r\n\r\n", url.path(), host);
+    let data = format!("GET {} HTTP/1.1\r\n\
+                        Host: {}\r\n\
+                        Connection: close\r\n\
+                        \r\n", url.path(), host);
     let stream = TcpStream::connect(&*addr)?;
     let timeout = Duration::from_secs(2);
     stream.set_read_timeout(Some(timeout))?;


### PR DESCRIPTION
Useful "Host" HTTP header comes from HTTP/1.1. Using it in a HTTP/1.0 context is not valid on the paper, despite it works well for both default URLs (official and fallback github mirror). I think using HTTP/1.1 instead is saner and more likely to succeed on custom URLs.

This requires to explicitly reject keep-alive connections (default behavior starting from HTTP/1.1) , otherwise read call timeouts waiting the end of stream. Since the result HTTP request is a bit long, I made it multi-line.